### PR TITLE
ENH: Parse RADOLAN flagged pixels as grid to NetCDF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,12 @@ before_install:
     - chmod +x miniconda.sh
     - ./miniconda.sh -b
     - export PATH=/home/travis/miniconda2/bin:$PATH
-    - conda config --add channels conda-forge
+    - conda config --prepend channels conda-forge
     - conda update --yes conda
     - conda info -a
 
 install:
-    - conda create -q -n radola_to_netcdf-env python=${TRAVIS_PYTHON_VERSION} --yes
+    - conda create -q -n radola_to_netcdf-env python=${TRAVIS_PYTHON_VERSION} --yes --strict-channel-priority
     - source activate radola_to_netcdf-env
     - conda install --yes $DEPS pip
     - conda install -c conda-forge --yes codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 install:
     - conda create -q -n radola_to_netcdf-env python=${TRAVIS_PYTHON_VERSION} --yes --strict-channel-priority
     - source activate radola_to_netcdf-env
-    - conda install --yes $DEPS pip
+    - conda install --yes $DEPS pip --strict-channel-priority
     - conda install -c conda-forge --yes codecov
     #- pip install coveralls
     - pip install pytest pytest-cov

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: python
 sudo: false
 matrix:
     include:
-    - python: "3.6"
+    - python: "3.7"
       env: DEPS="wradlib>=1.2.1
                  netCDF4
                  numpy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: python
 sudo: false
 matrix:
     include:
-    - python: "3.7"
+    - python: "3.6"
       env: DEPS="wradlib>=1.2.1
                  netCDF4
                  numpy"
@@ -17,6 +17,7 @@ before_install:
     - export PATH=/home/travis/miniconda2/bin:$PATH
     - conda config --prepend channels conda-forge
     - conda update --yes conda
+    - conda update --all --yes
     - conda info -a
 
 install:

--- a/README.rst
+++ b/README.rst
@@ -3,15 +3,14 @@ radolan_to_netcdf
 =================
 
 
-.. image:: https://img.shields.io/pypi/v/radolan_to_netcdf.svg
-        :target: https://pypi.python.org/pypi/radolan_to_netcdf
-
 .. image:: https://img.shields.io/travis/cchwala/radolan_to_netcdf.svg
         :target: https://travis-ci.org/cchwala/radolan_to_netcdf
 
-.. image:: https://readthedocs.org/projects/radolan-to-netcdf/badge/?version=latest
-        :target: https://radolan-to-netcdf.readthedocs.io/en/latest/?badge=latest
-        :alt: Documentation Status
+.. image:: https://img.shields.io/codecov/c/github/cchwala/radolan_to_netcdf
+        :target: https://codecov.io/gh/cchwala/radolan_to_netcdf
+
+.. image:: https://img.shields.io/pypi/v/radolan_to_netcdf.svg
+        :target: https://pypi.python.org/pypi/radolan_to_netcdf
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -15,17 +15,10 @@ radolan_to_netcdf
 
 
 
-Python package to parser RADOLAN binary data files to NetCDF
-
+Python package to parse RADOLAN binary data files to NetCDF
 
 * Free software: BSD license
-* Documentation: https://radolan-to-netcdf.readthedocs.io.
 
-
-Features
---------
-
-* TODO
 
 Credits
 -------

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ radolan_to_netcdf
 .. image:: https://img.shields.io/travis/cchwala/radolan_to_netcdf.svg
         :target: https://travis-ci.org/cchwala/radolan_to_netcdf
 
-.. image:: https://img.shields.io/codecov/c/github/cchwala/radolan_to_netcdf
+.. image:: https://img.shields.io/codecov/c/github/cchwala/radolan_to_netcdf.svg
         :target: https://codecov.io/gh/cchwala/radolan_to_netcdf
 
 .. image:: https://img.shields.io/pypi/v/radolan_to_netcdf.svg

--- a/radolan_to_netcdf/radolan_product_netcdf_config.py
+++ b/radolan_to_netcdf/radolan_product_netcdf_config.py
@@ -49,6 +49,22 @@ metadata_per_timestamp = {
             'grid_mapping': 'RADOLAN_grid',
         },
     },
+    'cluttermask': {
+        'variable_parameters': {
+            'datatype': 'i1',  # TODO: Check if NetCDF4 support bools
+            'dimensions': ('time', 'y', 'x'),
+            'chunksizes': (1, 900, 900),
+            'fill_value': -9999,
+            'zlib': True,
+            'complevel': 5,
+        },
+        'attributes': {
+            'long_name': 'Regions with no data',
+            'standard_name': 'secondary',
+            'coordinates': 'longitudes latitudes',
+            'grid_mapping': 'RADOLAN_grid',
+        },
+    },
 }
 
 radolan_product_netcdf_config = {

--- a/radolan_to_netcdf/radolan_product_netcdf_config.py
+++ b/radolan_to_netcdf/radolan_product_netcdf_config.py
@@ -17,6 +17,38 @@ metadata_per_timestamp = {
             'long_name': 'List of radar locations available at time stamp'
         },
     },
+    'secondary': {
+        'variable_parameters': {
+            'datatype': 'i1',  # TODO: Check if NetCDF4 support bools
+            'dimensions': ('time', 'y', 'x'),
+            'chunksizes': (1, 900, 900),
+            'fill_value': -9999,
+            'zlib': True,
+            'complevel': 5,
+        },
+        'attributes': {
+            'long_name': 'Regions filled in with interpolated station data',
+            'standard_name': 'secondary',
+            'coordinates': 'longitudes latitudes',
+            'grid_mapping': 'RADOLAN_grid',
+        },
+    },
+    'nodatamask': {
+        'variable_parameters': {
+            'datatype': 'i1',  # TODO: Check if NetCDF4 support bools
+            'dimensions': ('time', 'y', 'x'),
+            'chunksizes': (1, 900, 900),
+            'fill_value': -9999,
+            'zlib': True,
+            'complevel': 5,
+        },
+        'attributes': {
+            'long_name': 'Regions with no data',
+            'standard_name': 'secondary',
+            'coordinates': 'longitudes latitudes',
+            'grid_mapping': 'RADOLAN_grid',
+        },
+    },
 }
 
 radolan_product_netcdf_config = {
@@ -26,6 +58,7 @@ radolan_product_netcdf_config = {
                 'variable_parameters': {
                     'datatype': 'i2',
                     'dimensions': ('time', 'y', 'x'),
+                    'chunksizes': (1, 900, 900),
                     'fill_value': -9999,
                     'zlib': True,
                     'complevel': 5,

--- a/radolan_to_netcdf/radolan_to_netcdf.py
+++ b/radolan_to_netcdf/radolan_to_netcdf.py
@@ -191,7 +191,16 @@ def append_to_netcdf(fn, data_list, metadata_list):
                 temp_data[np.isnan(temp_data)] = fill_value_float
             else:
                 temp_data = data
-            nc_fh['rainfall_amount'][i_new, :, :] = temp_data
+            nc_fh[variable_name][i_new, :, :] = temp_data
+
+            # TODO: Remove this hardcoding of writing `secondary` and `nodatamask`
+            secondary = np.zeros_like(data, dtype='bool').flatten()
+            secondary[metadata['secondary']] = True
+            nc_fh['secondary'][i_new, :,: ] = secondary.reshape(data.shape)
+
+            nodatamask = np.zeros_like(data, dtype='bool').flatten()
+            nodatamask[metadata['nodatamask']] = True
+            nc_fh['nodatamask'][i_new, :, :] = nodatamask.reshape(data.shape)
 
             # TODO make this more flexible and also test for it !!!
             nc_fh['maxrange'][i_new] = int(metadata['maxrange'].split(' ')[0])

--- a/radolan_to_netcdf/radolan_to_netcdf.py
+++ b/radolan_to_netcdf/radolan_to_netcdf.py
@@ -202,6 +202,10 @@ def append_to_netcdf(fn, data_list, metadata_list):
             nodatamask[metadata['nodatamask']] = True
             nc_fh['nodatamask'][i_new, :, :] = nodatamask.reshape(data.shape)
 
+            cluttermask = np.zeros_like(data, dtype='bool').flatten()
+            cluttermask[metadata['cluttermask']] = True
+            nc_fh['cluttermask'][i_new, :, :] = cluttermask.reshape(data.shape)
+
             # TODO make this more flexible and also test for it !!!
             nc_fh['maxrange'][i_new] = int(metadata['maxrange'].split(' ')[0])
             nc_fh['radarlocations'][i_new] = ' '.join(

--- a/radolan_to_netcdf/tests/__init__.py
+++ b/radolan_to_netcdf/tests/__init__.py
@@ -1,3 +1,0 @@
-# -*- coding: utf-8 -*-
-
-"""Unit test package for radolan_to_netcdf."""

--- a/radolan_to_netcdf/tests/test_radolan_to_netcdf.py
+++ b/radolan_to_netcdf/tests/test_radolan_to_netcdf.py
@@ -48,16 +48,24 @@ def parse_and_validate_test_data(product_name):
     os.remove(fn)
 
 
+def test_RW():
+    parse_and_validate_test_data(product_name='RW')
+
+
+def test_YW():
+    parse_and_validate_test_data(product_name='YW')
+
+
 def test_flagged_pixels():
     fn_radolan_files = get_test_data_for_product(product_name='RW')
     fn_bin = fn_radolan_files[0]
     data, metadata = radolan_to_netcdf.read_in_one_bin_file(fn_bin)
     # Write file to NetCDF
-    fn = 'test12623323.nc'
+    fn = 'test.nc'
     radolan_to_netcdf.create_empty_netcdf(fn, product_name='RW')
     radolan_to_netcdf.append_to_netcdf(fn, [data, ], [metadata, ])
 
-    for flag_name in ['secondary', 'nodatamask']:
+    for flag_name in ['secondary', 'nodatamask', 'cluttermask']:
 
         # Read back and check flagged pixels
         with netCDF4.Dataset(fn, mode='r') as ds:
@@ -70,10 +78,3 @@ def test_flagged_pixels():
             np.testing.assert_almost_equal(actual, reference)
 
     os.remove(fn)
-
-class TestWriteToFile(unittest.TestCase):
-    def test_RW(self):
-        parse_and_validate_test_data(product_name='RW')
-    def test_YW(self):
-        parse_and_validate_test_data(product_name='YW')
-

--- a/radolan_to_netcdf/tests/test_radolan_to_netcdf.py
+++ b/radolan_to_netcdf/tests/test_radolan_to_netcdf.py
@@ -47,6 +47,30 @@ def parse_and_validate_test_data(product_name):
 
     os.remove(fn)
 
+
+def test_flagged_pixels():
+    fn_radolan_files = get_test_data_for_product(product_name='RW')
+    fn_bin = fn_radolan_files[0]
+    data, metadata = radolan_to_netcdf.read_in_one_bin_file(fn_bin)
+    # Write file to NetCDF
+    fn = 'test12623323.nc'
+    radolan_to_netcdf.create_empty_netcdf(fn, product_name='RW')
+    radolan_to_netcdf.append_to_netcdf(fn, [data, ], [metadata, ])
+
+    for flag_name in ['secondary', 'nodatamask']:
+
+        # Read back and check flagged pixels
+        with netCDF4.Dataset(fn, mode='r') as ds:
+            # Get data as matrix from NetCDF and derive the non-zero indices
+            # because this is how they are stored in RADOLAN bin files and
+            # wradlib returns them that way
+            actual = np.nonzero(ds[flag_name][0, :, :].flatten())[0]
+            reference = metadata[flag_name]
+
+            np.testing.assert_almost_equal(actual, reference)
+
+    os.remove(fn)
+
 class TestWriteToFile(unittest.TestCase):
     def test_RW(self):
         parse_and_validate_test_data(product_name='RW')


### PR DESCRIPTION
`wradlib` does parse the RADOLAN flags from bit 13, 14 and 15 and returns them in the metadata dict: 

```
{'producttype': 'YW',
 'datetime': datetime.datetime(2017, 8, 16, 0, 55),
 'radarid': '10000',
 'datasize': 1980000,
 'maxrange': '150 km',
 'radolanversion': '2.18.3',
 'precision': 0.01,
 'intervalseconds': 300,
 'nrow': 1100,
 'ncol': 900,
 'radarlocations': ['boo',
  'ros',
  'emd',
  'hnr',
  'umd',
  'pro',
  'ess',
  'fld',
  'drs',
  'neu',
  'nhb',
  'oft',
  'eis',
  'tur',
  'isn',
  'fbg',
  'mem'],
 'moduleflag': 0,
 'reanalysisversion': '2017.002',
 'intervalunit': 0,
 'nodataflag': nan,
 'secondary': array([], dtype=int64),
 'nodatamask': array([     0,      1,      2, ..., 989997, 989998, 989999]),
 'cluttermask': array([ 44353,  44354,  57945, ..., 938395, 943804, 944697])}
```

These flags,  `secondary`,`nodatamask`,  `cluttermask`, will be written to the NetCDF. For simplicity they will be stored as grids.