### PR TITLE
ENH: RADOLAN-RW binary file writer

### DIFF
--- a/radolan_to_netcdf/tests/test_write_to_netcdf.py
+++ b/radolan_to_netcdf/tests/test_write_to_netcdf.py
@@ -5,21 +5,10 @@ import glob
 import netCDF4
 import numpy as np
 from numpy.testing import assert_almost_equal
+
 from radolan_to_netcdf import radolan_to_netcdf
+from radolan_to_netcdf.tests.tools import get_test_data_for_product
 
-
-def get_test_data_path():
-    return pkg_resources.resource_filename('radolan_to_netcdf',
-                                           'tests/test_data')
-
-def get_test_data_for_product(product_name):
-    fn_patterns = {
-        'RW': 'radolan_rw/raa01-rw_10000-181122*---bin.gz',
-        'YW': 'radolan_yw/raa01-yw2017.002_10000*bin.gz'
-    }
-
-    return glob.glob(os.path.join(get_test_data_path(),
-                                  fn_patterns[product_name]))
 
 def parse_and_validate_test_data(product_name):
     fn = 'test.nc'

--- a/radolan_to_netcdf/tests/test_write_to_radolan_bin.py
+++ b/radolan_to_netcdf/tests/test_write_to_radolan_bin.py
@@ -64,22 +64,11 @@ class TestWradlibToRadolanBinaryRoundtrip(unittest.TestCase):
             data_reference, metadata_reference = radolan_to_netcdf.read_in_one_bin_file(
                 fn_radolan_file)
 
-            # TODO Remove this
-            # Add some errors to data and metadata for testing so that test can fail
-            #data_reference[500,500] = 42.0
-            metadata_reference['precision'] = 0.01
-
             wradlib_to_radolan_bin.write_to_radolan_bin_file(
                 fn='test_radolan.bin',
                 data=data_reference,
                 metadata=metadata_reference,
             )
-
-            # TODO Remove this
-            # Load reference file again to revert the introduced artificially
-            # errors from above
-            data_reference, metadata_reference = radolan_to_netcdf.read_in_one_bin_file(
-                fn_radolan_file)
 
             data_actual, metadata_actual = radolan_to_netcdf.read_in_one_bin_file(
                 'test_radolan.bin')

--- a/radolan_to_netcdf/tests/test_write_to_radolan_bin.py
+++ b/radolan_to_netcdf/tests/test_write_to_radolan_bin.py
@@ -29,3 +29,19 @@ class TestWradlibMetadataToHeader(unittest.TestCase):
         self.assertTrue(
             'Currently only RADOALN-RW is supported' in str(context.exception)
         )
+
+
+class TestWradlibDataToByteArray(unittest.TestCase):
+    def test_RW(self):
+        for fn_radolan_file in get_test_data_for_product('RW'):
+            data, metadata = radolan_to_netcdf.read_in_one_bin_file(
+                fn_radolan_file)
+
+            with wrl.io.radolan.get_radolan_filehandle(fn_radolan_file) as f:
+                header = wrl.io.radolan.read_radolan_header(f)
+                attrs = wrl.io.radolan.parse_dwd_composite_header(header)
+                reference = wrl.io.read_radolan_binary_array(f, attrs['datasize'])
+
+            actual = wradlib_to_radolan_bin.data_to_byte_array(data)
+
+            assert actual == reference

--- a/radolan_to_netcdf/tests/test_write_to_radolan_bin.py
+++ b/radolan_to_netcdf/tests/test_write_to_radolan_bin.py
@@ -7,13 +7,25 @@ from radolan_to_netcdf import wradlib_to_radolan_bin
 from radolan_to_netcdf.tests.tools import get_test_data_for_product
 
 class TestWradlibMetadataToHeader(unittest.TestCase):
-    for fn_radolan_file in get_test_data_for_product('RW'):
-        data, metadata = radolan_to_netcdf.read_in_one_bin_file(
-            fn_radolan_file)
+    def test_RW(self):
+        for fn_radolan_file in get_test_data_for_product('RW'):
+            data, metadata = radolan_to_netcdf.read_in_one_bin_file(
+                fn_radolan_file)
 
-        with wrl.io.radolan.get_radolan_filehandle(fn_radolan_file) as f:
-            reference = wrl.io.radolan.read_radolan_header(f)
+            with wrl.io.radolan.get_radolan_filehandle(fn_radolan_file) as f:
+                reference = wrl.io.radolan.read_radolan_header(f)
 
-        actual = wradlib_to_radolan_bin.metadata_to_header(metadata)
+            actual = wradlib_to_radolan_bin.metadata_to_header(metadata)
 
-        assert actual == reference
+            assert actual == reference
+
+    def test_not_RW_error(self):
+        with self.assertRaises(NotImplementedError) as context:
+            fn_radolan_files = get_test_data_for_product('YW')
+            data, metadata = radolan_to_netcdf.read_in_one_bin_file(
+                fn_radolan_files[0])
+            wradlib_to_radolan_bin.metadata_to_header(metadata)
+
+        self.assertTrue(
+            'Currently only RADOALN-RW is supported' in str(context.exception)
+        )

--- a/radolan_to_netcdf/tests/test_write_to_radolan_bin.py
+++ b/radolan_to_netcdf/tests/test_write_to_radolan_bin.py
@@ -1,0 +1,19 @@
+import unittest
+import wradlib as wrl
+import numpy as np
+
+from radolan_to_netcdf import radolan_to_netcdf
+from radolan_to_netcdf import wradlib_to_radolan_bin
+from radolan_to_netcdf.tests.tools import get_test_data_for_product
+
+class TestWradlibMetadataToHeader(unittest.TestCase):
+    for fn_radolan_file in get_test_data_for_product('RW'):
+        data, metadata = radolan_to_netcdf.read_in_one_bin_file(
+            fn_radolan_file)
+
+        with wrl.io.radolan.get_radolan_filehandle(fn_radolan_file) as f:
+            reference = wrl.io.radolan.read_radolan_header(f)
+
+        actual = wradlib_to_radolan_bin.metadata_to_header(metadata)
+
+        assert actual == reference

--- a/radolan_to_netcdf/tests/test_write_to_radolan_bin.py
+++ b/radolan_to_netcdf/tests/test_write_to_radolan_bin.py
@@ -42,6 +42,6 @@ class TestWradlibDataToByteArray(unittest.TestCase):
                 attrs = wrl.io.radolan.parse_dwd_composite_header(header)
                 reference = wrl.io.read_radolan_binary_array(f, attrs['datasize'])
 
-            actual = wradlib_to_radolan_bin.data_to_byte_array(data)
+            actual = wradlib_to_radolan_bin.data_to_byte_array(data, metadata)
 
             assert actual == reference

--- a/radolan_to_netcdf/tests/test_write_to_radolan_bin.py
+++ b/radolan_to_netcdf/tests/test_write_to_radolan_bin.py
@@ -45,3 +45,14 @@ class TestWradlibDataToByteArray(unittest.TestCase):
             actual = wradlib_to_radolan_bin.data_to_byte_array(data, metadata)
 
             assert actual == reference
+
+    def test_not_RW_error(self):
+        with self.assertRaises(NotImplementedError) as context:
+            fn_radolan_files = get_test_data_for_product('YW')
+            data, metadata = radolan_to_netcdf.read_in_one_bin_file(
+                fn_radolan_files[0])
+            wradlib_to_radolan_bin.data_to_byte_array(data, metadata)
+
+        self.assertTrue(
+            'Currently only RADOALN-RW is supported' in str(context.exception)
+        )

--- a/radolan_to_netcdf/tests/tools.py
+++ b/radolan_to_netcdf/tests/tools.py
@@ -1,0 +1,17 @@
+import pkg_resources
+import glob
+import os
+
+
+def get_test_data_path():
+    return pkg_resources.resource_filename('radolan_to_netcdf',
+                                           'tests/test_data')
+
+def get_test_data_for_product(product_name):
+    fn_patterns = {
+        'RW': 'radolan_rw/raa01-rw_10000-181122*---bin.gz',
+        'YW': 'radolan_yw/raa01-yw2017.002_10000*bin.gz'
+    }
+
+    return glob.glob(os.path.join(get_test_data_path(),
+                                  fn_patterns[product_name]))

--- a/radolan_to_netcdf/wradlib_to_radolan_bin.py
+++ b/radolan_to_netcdf/wradlib_to_radolan_bin.py
@@ -1,4 +1,5 @@
-import wradlib as wrl
+import datetime
+import numpy as np
 
 
 def metadata_to_header(metadata):
@@ -17,4 +18,71 @@ def metadata_to_header(metadata):
 
     """
 
-    return None
+    if metadata['producttype'] != 'RW':
+        raise NotImplementedError('Currently only RADOALN-RW is supported')
+
+    len_header_fixed_part = 82
+    len_header_radar_locations = len(
+        '<' + ','.join(metadata['radarlocations']) + '> ')
+
+    len_header = len_header_fixed_part + len_header_radar_locations
+
+    # Generate empty header with only whitespaces
+    header_out = np.array(['', ] * len_header, dtype='S1')
+    header_out[:] = ' '
+
+    # Fill header with metadata and tokens
+    header_out[0:2] = list(metadata['producttype'])
+    header_out[2:8] = list(
+        datetime.datetime.strftime(metadata['datetime'], '%d%H%M'))
+    header_out[8:13] = list(metadata['radarid'])
+    header_out[13:17] = list(
+        datetime.datetime.strftime(metadata['datetime'], '%m%y'))
+
+    header_out[17:19] = list('BY')
+    # Have to add one here to get correct length in header string.
+    # Do not know why. Maybe because of the 'etx' char
+    header_out[19:26] = list(str(metadata['datasize'] + len_header + 1))
+
+    header_out[26:28] = list('VS')
+    header_out[28:30] = list(
+        {
+            '100 km and 128 km (mixed)': ' 0',
+            '100 km': ' 1',
+            '128 km': ' 2',
+            '150 km': ' 3'
+        }.get(metadata['maxrange'])
+    )
+
+    header_out[30:32] = list('SW')
+    header_out[32:41] = list(metadata['radolanversion'].rjust(9))
+
+    header_out[41:43] = list('PR')
+    header_out[43:48] = list(
+        {
+            0.01: ' E-02',
+            0.1: ' E-01',
+            1: ' E-00',
+        }.get(metadata['precision'])
+    )
+
+    header_out[48:51] = list('INT')
+    header_out[51:55] = list(
+        str(int(metadata['intervalseconds'] / 60)).rjust(4))
+
+    header_out[55:57] = list('GP')
+    header_out[57:66] = list(
+        str(metadata['nrow']).rjust(4) + 'x' + str(metadata['ncol']).rjust(4))
+
+    header_out[66:68] = list('MF')
+    header_out[69:77] = list(str(int(metadata['moduleflag'])).zfill(8))
+
+    header_out[77:79] = list('MS')
+    header_out[79:82] = list(str(int(len_header_radar_locations)).rjust(3))
+
+    header_out[82:(82 + len_header_radar_locations)] = list(
+        '<' + ','.join(metadata['radarlocations']) + '> ')
+
+    header_out = b''.join(header_out).decode()
+
+    return header_out

--- a/radolan_to_netcdf/wradlib_to_radolan_bin.py
+++ b/radolan_to_netcdf/wradlib_to_radolan_bin.py
@@ -1,0 +1,20 @@
+import wradlib as wrl
+
+
+def metadata_to_header(metadata):
+    """
+
+    Parameters
+    ----------
+    metadata : dict
+        Dict of metadata as returned by wradlib.io.read_radolan_composite
+
+    Returns
+    -------
+
+    header : byte string
+        Header byte string conforming to the definition of RADOALN binary files
+
+    """
+
+    return None

--- a/radolan_to_netcdf/wradlib_to_radolan_bin.py
+++ b/radolan_to_netcdf/wradlib_to_radolan_bin.py
@@ -100,6 +100,9 @@ def data_to_byte_array(data , metadata):
 
     """
 
+    if metadata['producttype'] != 'RW':
+        raise NotImplementedError('Currently only RADOALN-RW is supported')
+
     arr = (data / metadata['precision']).flatten().astype(np.uint16)
 
     secondary = np.zeros_like(arr, dtype=np.uint16)

--- a/radolan_to_netcdf/wradlib_to_radolan_bin.py
+++ b/radolan_to_netcdf/wradlib_to_radolan_bin.py
@@ -86,3 +86,17 @@ def metadata_to_header(metadata):
     header_out = b''.join(header_out).decode()
 
     return header_out
+
+def data_to_byte_array(data):
+    """
+
+    Parameters
+    ----------
+    data
+
+    Returns
+    -------
+
+    """
+
+    pass

--- a/radolan_to_netcdf/wradlib_to_radolan_bin.py
+++ b/radolan_to_netcdf/wradlib_to_radolan_bin.py
@@ -87,16 +87,30 @@ def metadata_to_header(metadata):
 
     return header_out
 
-def data_to_byte_array(data):
+def data_to_byte_array(data , metadata):
     """
 
     Parameters
     ----------
     data
+    metadata
 
     Returns
     -------
 
     """
 
-    pass
+    arr = (data / metadata['precision']).flatten().astype(np.uint16)
+
+    secondary = np.zeros_like(arr, dtype=np.uint16)
+    secondary[metadata['secondary']] = 0x1000
+
+    nodatamask = np.zeros_like(arr, dtype=np.uint16)
+    nodatamask[metadata['nodatamask']] = 0b0010100111000100
+
+    cluttermask = np.zeros_like(arr, dtype=np.uint16)
+    cluttermask[metadata['cluttermask']] = 0x8000
+
+    arr = arr | secondary | nodatamask | cluttermask
+
+    return arr.tobytes()

--- a/radolan_to_netcdf/wradlib_to_radolan_bin.py
+++ b/radolan_to_netcdf/wradlib_to_radolan_bin.py
@@ -117,3 +117,26 @@ def data_to_byte_array(data , metadata):
     arr = arr | secondary | nodatamask | cluttermask
 
     return arr.tobytes()
+
+
+def write_to_radolan_bin_file(fn, data, metadata):
+    """
+
+    Parameters
+    ----------
+    fn
+    data
+    metadata
+
+    Returns
+    -------
+
+    """
+
+    data_as_byte_str = data_to_byte_array(data, metadata)
+    header_as_byte_str = metadata_to_header(metadata)
+
+    with open(fn, mode='wb') as f:
+        f.write(header_as_byte_str.encode())
+        f.write(b'\x03')
+        f.write(data_as_byte_str)


### PR DESCRIPTION
Add option to write RADOLAN-bin files. For now, it is enough if this works for RADOLAN-RW.

This PR makes it possible to write to RADOLAN-bin files using `data` and `metadata` as returned e.g. by `wradlib.io.read_radolan_composite`.

It can be used like this

```python
wradlib_to_radolan_bin.write_to_radolan_bin_file(
    fn=file_name,
    data=data_np_array,
    metadata=metadata_dict,
)
```