### PR TITLE
Divided RW-product to "recent" and "reprocessed"

### DIFF
--- a/radolan_to_netcdf/radolan_product_netcdf_config.py
+++ b/radolan_to_netcdf/radolan_product_netcdf_config.py
@@ -66,7 +66,7 @@ metadata_per_timestamp = {
 }
 
 radolan_product_netcdf_config = {
-    "RW": {
+    "RW-recent": {
         "variables": {
             "rainfall_amount": {
                 "variable_parameters": {
@@ -94,6 +94,36 @@ radolan_product_netcdf_config = {
             "n_lons": 900,
         },
     },
+
+    "RW-reprocessed": {
+        "variables": {
+            "rainfall_amount": {
+                "variable_parameters": {
+                    "datatype": "i2",
+                    "dimensions": ("time", "y", "x"),
+                    "chunksizes": (1, 1100, 900),
+                    "fill_value": -9999,
+                    "zlib": True,
+                    "complevel": 5,
+                },
+                "attributes": {
+                    "long_name": "Hourly rainfall",
+                    "standard_name": "rainfall_amount",
+                    "units": "kg",
+                    "scale_factor": 0.1,
+                    "add_offset": 0,
+                    "coordinates": "longitudes latitudes",
+                    "grid_mapping": "RADOLAN_grid",
+                },
+            },
+        },
+        "metadata_per_timestamp": metadata_per_timestamp,
+        "metadata_fixed": {
+            "n_lats": 1100,
+            "n_lons": 900,
+        },
+    },
+
     "YW": {
         "variables": {
             "rainfall_amount": {

--- a/radolan_to_netcdf/radolan_to_netcdf.py
+++ b/radolan_to_netcdf/radolan_to_netcdf.py
@@ -170,6 +170,13 @@ def append_to_netcdf(fn, data_list, metadata_list):
             )
 
             product_name = metadata["producttype"]
+
+            #here's the new bit, since DWD calls both products "RW"
+            if product_name == "RW" and "reanalysisversion" in metadata:
+                product_name = "RW-reprocessed"
+            else:
+                product_name = "RW-recent"
+
             product_config_dict = radolan_product_netcdf_config[product_name]
 
             if product_name != nc_fh.producttype:


### PR DESCRIPTION
Divided product type "RW" into two classes: "RW-reprocessed" and "RW-recent" because these two products have different x,y resolutions:
reprocessed:  900, 1100
recent: 900, 900

I chose the naming of the DWD-opendata server. For the "hourly" product "RW" you can choose between "recent",  and "reprocessed". Reprocessed is the description for the RADKLIM reanalysis.

The metadata of the RW-reprocessed data contains the keyword "reanalysisversion". 

I think for the user it is the easiest to stick to the names which can be seen on the opendata server (recent and reprocessed). 

Other ideas for the naming could be: 
- "Radolan-RW " for "RW-recent" and "RADKLIM-RW" for "RW-reprocessed"
- "RW-reanalysis" for "RW-reprocessed"

As far as I have seen, there is no such differences for the other products YW and RY.

The suggested fix will fail, as soon as the DWD changes the metadata-format because the decision is based on the entry in the metadata ("reanalysisversion") which is not existent in the metadata of RW-recent.


