### PR TITLE
change datatypes of fill_value for netcdf

### DIFF
--- a/radolan_to_netcdf/radolan_product_netcdf_config.py
+++ b/radolan_to_netcdf/radolan_product_netcdf_config.py
@@ -17,7 +17,7 @@ metadata_per_timestamp = {
     },
     "secondary": {
         "variable_parameters": {
-            "datatype": "i1",  # TODO: Check if NetCDF4 support bools
+            "datatype": "i2",  # TODO: Check if NetCDF4 support bools
             "dimensions": ("time", "y", "x"),
             "chunksizes": (1, 900, 900),
             "fill_value": -9999,
@@ -33,7 +33,7 @@ metadata_per_timestamp = {
     },
     "nodatamask": {
         "variable_parameters": {
-            "datatype": "i1",  # TODO: Check if NetCDF4 support bools
+            "datatype": "i2",  # TODO: Check if NetCDF4 support bools
             "dimensions": ("time", "y", "x"),
             "chunksizes": (1, 900, 900),
             "fill_value": -9999,
@@ -49,7 +49,7 @@ metadata_per_timestamp = {
     },
     "cluttermask": {
         "variable_parameters": {
-            "datatype": "i1",  # TODO: Check if NetCDF4 support bools
+            "datatype": "i2",  # TODO: Check if NetCDF4 support bools
             "dimensions": ("time", "y", "x"),
             "chunksizes": (1, 900, 900),
             "fill_value": -9999,


### PR DESCRIPTION
Adresses issue https://github.com/cchwala/radolan_to_netcdf/issues/15 
Explanation: datatype changed from i1 to i2 to allow for fill_values = -9999 since this leads to overflow errors when executing for example this line in the notebooks: ´rtn.create_empty_netcdf(fn=fn_netcdf, product_name='YW')´

No dependencies have been checked, so there might be other aspects that are not treated by this approach. 